### PR TITLE
Make the API more ircu2-like by parsing CIDRs outside the library

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,2 +1,2 @@
-bench-cidr
+bench-cidr-lookups
 cidr

--- a/configure.pl
+++ b/configure.pl
@@ -34,7 +34,6 @@ load_vars();
 add_exe('cidr', '', 'src/cidr_lookups.c', 'src/irc_stuff.c', 'tests/tests.c');
 add_exe('example', '', 'src/cidr_lookups.c', 'src/irc_stuff.c', 'example.c');
 add_exe('bench-cidr-lookups', '-lm', 'src/cidr_lookups.c', 'src/irc_stuff.c', 'bench-cidr-lookups.o');
-add_exe('bench-lpc-trie', '-lm', 'src/lpc_trie.c', 'src/irc_stuff.c', 'bench-lpc-trie.o');
 
 # Emit the output file.
 my ($fh, $filename) = tempfile('build.ninja.XXXXXX');

--- a/include/cidr_lookups.h
+++ b/include/cidr_lookups.h
@@ -1,7 +1,11 @@
 #ifndef __CIDR_LOOKUPS_H
 #define __CIDR_LOOKUPS_H
 
-#include "irc_stuff.h"
+/** Structure to store an IP address. */
+struct irc_in_addr
+{
+  unsigned short in6_16[8]; /**< IPv6 encoded parts, little-endian. */
+};
 
 typedef struct _cidr_node {
     struct irc_in_addr ip;
@@ -70,7 +74,7 @@ do {  \
  */
 #define CIDR_SEARCH_ALL_MATCHES(root, node, ip) \
 do { \
-    cidr_node *_node = cidr_search_best(root, (ip)); \
+    cidr_node *_node = cidr_search_best(root, (ip), 128); \
     while ((node = _node)) { \
         if (_node->data) \
 
@@ -87,40 +91,45 @@ cidr_root_node *cidr_new_tree();
 
 /** cidr_add_node - add a new node to the CIDR tree
  * @param[in] root_tree Pointer to the root of the CIDR tree
- * @param[in] cidr_string_format CIDR string format
+ * @param[in] ip IP address (mask) to store
+ * @param[in] nbits Length of CIDR prefix in \a ip
  * @param[in] data Pointer to the data associated with the node
  * @return Pointer to the added CIDR node
  */
-cidr_node *cidr_add_node(const cidr_root_node *root_tree, const char *cidr_string_format, void *data);
+cidr_node *cidr_add_node(const cidr_root_node *root_tree, const struct irc_in_addr *ip, unsigned char nbits, void *data);
 
 /** _cidr_find_exact_node - find a node in the CIDR tree
  * @param[in] root_tree Pointer to the root of the CIDR tree
- * @param[in] cidr_string_format CIDR string format
+ * @param[in] ip IP address (mask) to look up
+ * @param[in] nbits Length of CIDR prefix in \a ip
  * @return Pointer to the found CIDR node
  */
-cidr_node *_cidr_find_exact_node(const cidr_root_node *root_tree, const char *cidr_string_format);
+#define _cidr_find_exact_node(TREE, IP, BITS) _cidr_find_node(TREE, IP, BITS, 1)
 
 /** cidr_search_best - find a non-virtual node in the CIDR tree that covers the given CIDR string
  * @param[in] root_tree Pointer to the root of the CIDR tree
- * @param[in] cidr_string_format CIDR string format
+ * @param[in] ip IP address (mask) to look up
+ * @param[in] nbits Length of CIDR prefix in \a ip
  * @return Pointer to the found CIDR node, returns NULL if not found
  */
-cidr_node *cidr_search_best(const cidr_root_node *root_tree, const char *cidr_string_format);
+#define cidr_search_best(TREE, IP, BITS) _cidr_find_node(TREE, IP, BITS, 0)
 
 /** _cidr_find_node - find a node in the CIDR tree
  * @param[in] root_tree Pointer to the root of the CIDR tree
- * @param[in] cidr_string_format CIDR string format
+ * @param[in] ip IP address (mask) to look up
+ * @param[in] nbits Length of CIDR prefix in \a ip
  * @param[in] is_exact If 0, returns the closest parent node that is not virtual, otherwise returns the exact node if found
  * @return Pointer to the found CIDR node, returns NULL if not found
  */
-cidr_node *_cidr_find_node(const cidr_root_node *root_tree, const char *cidr_string_format, const unsigned short is_exact);
+cidr_node *_cidr_find_node(const cidr_root_node *root_tree, const struct irc_in_addr *ip, unsigned char nbits, const unsigned short is_exact);
 
 /** cidr_rem_node_by_cidr - remove a node from the CIDR tree by CIDR string
  * @param[in] root_tree Pointer to the root of the CIDR tree
- * @param[in] cidr_string_format CIDR string format
+ * @param[in] ip IP address (mask) to remove
+ * @param[in] nbits Length of CIDR prefix in \a ip
  * @return 1 if the node was removed, 0 otherwise
  */
-int cidr_rem_node_by_cidr(const cidr_root_node *root_tree, const char *cidr_string_format);
+int cidr_rem_node_by_cidr(const cidr_root_node *root_tree, const struct irc_in_addr *ip, unsigned char nbits);
 
 /** cidr_rem_node - remove a node from the CIDR tree
  * @param[in] node Pointer to the node to be removed
@@ -130,10 +139,11 @@ int cidr_rem_node(cidr_node *node);
 
 /** cidr_get_data - get data associated with a node in the CIDR tree
  * @param[in] root_tree Pointer to the root of the CIDR tree
- * @param[in] cidr_string_format CIDR string format
+ * @param[in] ip IP address (mask) to look up
+ * @param[in] nbits Length of CIDR prefix in \a ip
  * @return Pointer to the data associated with the node
  */
-void *cidr_get_data(const cidr_root_node *root_tree, const char *cidr_string_format);
+void *cidr_get_data(const cidr_root_node *root_tree, const struct irc_in_addr *ip, unsigned char nbits);
 
 /** get_cidr_mask - get the CIDR mask of a node
  *  Be careful: it returns a pointer to a static buffer that gets overwritten on each call

--- a/include/irc_stuff.h
+++ b/include/irc_stuff.h
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <netinet/in.h>
 
+#include "cidr_lookups.h" /* irc_in_addr */
 
 #define SOCKIPLEN 45
 #define CIDR_LEN 43
@@ -34,11 +35,6 @@
                                   || (A)->in6_16[7] != (B)->in6_16[7] || !irc_in_addr_is_ipv4(B)) \
                               : memcmp((A), (B), sizeof(struct irc_in_addr)))
 
-/** Structure to store an IP address. */
-struct irc_in_addr
-{
-  unsigned short in6_16[8]; /**< IPv6 encoded parts, little-endian. */
-};
 
 
 /* Created my own IsDigit. Did not take macro from ircu */

--- a/src/cidr_lookups.c
+++ b/src/cidr_lookups.c
@@ -9,8 +9,12 @@
 #define MAX_DEBUG_PAYLOAD 2048
 
 // local functions
-static void DEBUG (char const *format, ...) __attribute__((format(printf, 1, 2)));
 static cidr_node* _cidr_create_node(const struct irc_in_addr *ip, const unsigned char bits, void *data);
+#if defined(CIDR_DEBUG_ENABLED)
+static void DEBUG(char const *format, ...) __attribute__((format(printf, 1, 2)));
+#else
+# define DEBUG(...)
+#endif
 static cidr_node* _get_closest_parent_node(const cidr_node *node);
 
 /** _cidr_bit_diff - find first mismatching bit
@@ -342,6 +346,7 @@ unsigned short _cidr_get_bit(const struct irc_in_addr *ip, const unsigned int bi
     return ip16;
 }
 
+#if defined(CIDR_DEBUG_ENABLED)
 /** DEBUG - debug message handler
  * @param[in] format Format string
  * @param[in] ... Variable arguments
@@ -352,9 +357,6 @@ static void DEBUG (char const *format, ...)
 	int nchars;
 	char outbuf[MAX_DEBUG_PAYLOAD+3];
 
-#ifndef CIDR_DEBUG_ENABLED
-    return;
-#endif
 	va_start(vl, format);
 	nchars = vsnprintf(outbuf, MAX_DEBUG_PAYLOAD+1, format, vl);
 	va_end(vl);
@@ -365,6 +367,7 @@ static void DEBUG (char const *format, ...)
     printf("%s", outbuf);
 	return;
 }
+#endif
 
 /** _cidr_create_node - create a new CIDR node
  * @param[in] ip IP address

--- a/tests/bench-cidr.c
+++ b/tests/bench-cidr.c
@@ -331,7 +331,7 @@ void bench_report(const char *phase, uint64_t count)
 	/* Collect malloc statistics. */
 #if defined(HAS_MSTATS)
 	m_stats = mstats();
-	printf(" ... %zu bytes_total, %zu chunks_used, %zu bytes_used, %zu chunks_free, %zd bytes_free\n",
+	printf(" ... %zd bytes_total, %zd chunks_used, %zd bytes_used, %zd chunks_free, %zd bytes_free\n",
 		m_stats.bytes_total - b_m_stats.bytes_total,
 		m_stats.chunks_used - b_m_stats.chunks_used,
 		m_stats.bytes_used - b_m_stats.bytes_used,
@@ -470,17 +470,9 @@ int prng_weighted(uint64_t w[], int count)
 int entry_cmp(const void *va, const void *vb)
 {
 	const struct entry *a = va, *b = vb;
-	int ii, jj;
+	int ii;
 
-	/* First, sort IPv4 < IPv6. */
-	ii = irc_in_addr_is_ipv4(&a->addr);
-	jj = irc_in_addr_is_ipv4(&b->addr);
-	if (ii != jj)
-	{
-		return jj - ii;
-	}
-
-	/* Next, sort mask < full < miss. */
+	/* First, sort mask < full < miss. */
 	if (a->nbits != b->nbits)
 	{
 		if (a->nbits == 0) return 1;

--- a/tests/bench-cidr.c
+++ b/tests/bench-cidr.c
@@ -63,9 +63,8 @@
 
 #if defined(CIDR_LOOKUPS_API)
 # include "../include/cidr_lookups.h"
-#else
-# include "../include/irc_stuff.h"
 #endif
+#include "../include/irc_stuff.h"
 
 #if defined(__DARWIN_C_LEVEL)
 # define HAS_MSTATS
@@ -146,11 +145,11 @@ void table_map(const struct entry *entry, void *value)
 #if defined(CIDR_LOOKUPS_API)
 	if (value)
 	{
-		cidr_add_node(cidr_root, entry->text, value);
+		cidr_add_node(cidr_root, &entry->addr, entry->nbits, value);
 	}
 	else
 	{
-		cidr_rem_node_by_cidr(cidr_root, entry->text);
+		cidr_rem_node_by_cidr(cidr_root, &entry->addr, entry->nbits);
 	}
 #endif
 }
@@ -158,7 +157,7 @@ void table_map(const struct entry *entry, void *value)
 void *table_lookup(const struct entry *entry)
 {
 #if defined(CIDR_LOOKUPS_API)
-	cidr_node *node = cidr_search_best(cidr_root, entry->text);
+	const cidr_node *node = cidr_search_best(cidr_root, &entry->addr, entry->nbits);
 	return node ? node->data : NULL;
 #endif
 }


### PR DESCRIPTION
Fix some residual bugs in the current code, then implement some speedups.

Times in nanosec/operation on an Apple M2 Max / Threadripper 3960X (these seem fairly noisy, run to run):

| plan | load | update | lookup | reload | commit |
| --- | --- | --- | --- | --- | --- |
| 351.105 / 381.06 | 269.333 / 228.938 | 368.334 / 349.448 | 208.773 / 262.95 | 261.778 / 240.289 | configure.pl: Remove build of non-existent file |
| 187.674 / 252.938 | 222.049 / 295.204 | 379.61 / 429.715 | 246.486 / 309.174 | 284.41 / 313.804 | bench-cidr.c: Fix sorting of entries |
| 180.43 / 287.662 | 242.094 / 295.867 | 291.738 / 338.364 | 247.395 / 303.186 | 263.697 / 301.912 | cidr_lookups: Only eval DEBUG arguments when debugging |
| 182 / 282.874 | 87.7506 / 96.7829 | 138.587 / 133.799 | 16.9236 / 23.1139 | 136.526 / 111.072 | Do not parse masks within the trie API |

